### PR TITLE
beeb -f option uses $BBC_FILE if defined

### DIFF
--- a/tools/mmb_utils/BeebUtils.pm
+++ b/tools/mmb_utils/BeebUtils.pm
@@ -42,7 +42,7 @@ my $DiskInvalid = 0xFF;
 # Almost a constant.  What we're gonna do here is nasty, but it means
 # that any program that uses this module will automatically gain an
 # optional "-f filename"
-my $DEFAULT_BBC_FILE="BEEB.MMB";
+my $DEFAULT_BBC_FILE=defined $ENV{'BBC_FILE'} ? $ENV{'BBC_FILE'} : "BEEB.MMB";
 
 our $BBC_FILE="";
 


### PR DESCRIPTION
if undefined, defaults to 'BEEB.MMB', as before

makes the tool a little nicer to use, if your BEEB.MMB file is a stored somewhere else (like on an SD card in another directory - you don't need to keep using the -f option and specifying the path)