### PR TITLE
Fix: uses tr instead of bash4-ism to lower-case

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,7 +61,7 @@ do
     do
         build=build/${device}
         mkdir -p ${build}
-        ssd=${build}/${system,,}.ssd
+        ssd=${build}/$(echo ${system} | tr '[:upper:]' '[:lower:]').ssd
         rm -f ${ssd}
 
         # Configure the system/device to be assembled


### PR DESCRIPTION
used in name of .ssd file

${var,,} syntax is not available in bash3 (which is standard on macOS,
at least up to Catalina)

This prevents building in macOS out of the box, so seems worth fixing.  The change works fine on Linux, too, as least on Ubuntu 16.04-20.04 which run bash 4-5 and have 'tr', to.