### PR TITLE
MM32.asm : Adjust LDX instruction to use owtableZ-1 &7F Emulation

### DIFF
--- a/MM32.asm
+++ b/MM32.asm
@@ -2235,7 +2235,7 @@ Rfault=&FF
 	LDY #6
 	LDA (cb),Y		; A=FDC command
 
-	LDX #owtableZ
+	LDX #owtableZ-1
 
 .loop1
 	CMP owtable1,X


### PR DESCRIPTION
Originally the LDX would load a byte from beyond the table . Found with Claude.